### PR TITLE
Add zero-width space character to escape the `@` symbol in doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4
+- Fixed links in docs.
+
 ## 0.0.3
 - Unlock SDK >= 3.1.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.4
 - Fixed links in docs.
+- Updated supported platforms.
 
 ## 0.0.3
 - Unlock SDK >= 3.1.0.

--- a/lib/deno_postgres_interop.dart
+++ b/lib/deno_postgres_interop.dart
@@ -1,4 +1,4 @@
-/// An interop for [deno-postgres@​0.17.0](https://deno.land/x/postgres@v0.17.0).
+/// An interop for [deno-postgres@v​0.17.0](https://deno.land/x/postgres@v0.17.0).
 library;
 
 export 'src/client.dart';

--- a/lib/deno_postgres_interop.dart
+++ b/lib/deno_postgres_interop.dart
@@ -1,4 +1,4 @@
-/// An interop for [deno-postgres@v0.17.0](https://deno.land/x/postgres@v0.17.0).
+/// An interop for [deno-postgres@​0.17.0](https://deno.land/x/postgres@v0.17.0).
 library;
 
 export 'src/client.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -4,16 +4,16 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/client_options.dart';
 import 'package:deno_postgres_interop/src/query_client.dart';
 
-/// [deno-postgres@v0.17.0/Client](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client).
+/// [deno-postgres@​0.17.0/Client](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client).
 @JS()
 class Client extends QueryClient {
-  /// [deno-postgres@v0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   external factory Client(String dbUrl);
 
-  /// [deno-postgres@v0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   factory Client.config(ClientOptions config) =>
       callConstructor('Client', [config]);
 
-  /// [deno-postgres@v0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   factory Client.empty() => callConstructor('Client', null);
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -4,16 +4,16 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/client_options.dart';
 import 'package:deno_postgres_interop/src/query_client.dart';
 
-/// [deno-postgres@​0.17.0/Client](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client).
+/// [deno-postgres@v​0.17.0/Client](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client).
 @JS()
 class Client extends QueryClient {
-  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@v​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   external factory Client(String dbUrl);
 
-  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@v​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   factory Client.config(ClientOptions config) =>
       callConstructor('Client', [config]);
 
-  /// [deno-postgres@​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
+  /// [deno-postgres@v​0.17.0/Client/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Client#ctor_0).
   factory Client.empty() => callConstructor('Client', null);
 }

--- a/lib/src/client_common.dart
+++ b/lib/src/client_common.dart
@@ -3,13 +3,13 @@ import 'package:deno_postgres_interop/src/query_object_options.dart';
 import 'package:deno_postgres_interop/src/query_object_result.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/QueryArguments](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArguments).
+/// [deno-postgres@v​0.17.0/QueryArguments](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArguments).
 typedef QueryArguments = Object;
 
 /// This class hosts common interops for clients.
 class ClientCommon {
-  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
-  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
+  /// [deno-postgres@v​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
   static Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     Object queryable,
     String query, [
@@ -17,8 +17,8 @@ class ClientCommon {
   ]) =>
       _query('queryArray', queryable, query, arguments);
 
-  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
-  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
+  /// [deno-postgres@v​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
   static Future<QueryArrayResult<T>>
       queryArrayWithOptions<T extends List<dynamic>>(
     Object queryable,
@@ -38,8 +38,8 @@ class ClientCommon {
   // ): Promise<QueryArrayResult<T>>
   // https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_2
 
-  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
-  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
+  /// [deno-postgres@v​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
   static Future<QueryObjectResult<T>> queryObject<T>(
     Object queryable,
     String query, [
@@ -47,8 +47,8 @@ class ClientCommon {
   ]) =>
       _query('queryObject', queryable, query, arguments);
 
-  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
-  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
+  /// [deno-postgres@v​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
   static Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     Object queryable,
     QueryObjectOptions config,
@@ -61,7 +61,7 @@ class ClientCommon {
   //
   // [related issue](https://github.com/dart-lang/language/issues/1988).
   //
-  // [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_2).
+  // [deno-postgres@v​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_2).
   // Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
   //   List<String> query,
   //   List args,

--- a/lib/src/client_common.dart
+++ b/lib/src/client_common.dart
@@ -3,13 +3,13 @@ import 'package:deno_postgres_interop/src/query_object_options.dart';
 import 'package:deno_postgres_interop/src/query_object_result.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/QueryArguments](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArguments).
+/// [deno-postgres@​0.17.0/QueryArguments](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArguments).
 typedef QueryArguments = Object;
 
 /// This class hosts common interops for clients.
 class ClientCommon {
-  /// [deno-postgres@v0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
-  /// [deno-postgres@v0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
+  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
+  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
   static Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     Object queryable,
     String query, [
@@ -17,8 +17,8 @@ class ClientCommon {
   ]) =>
       _query('queryArray', queryable, query, arguments);
 
-  /// [deno-postgres@v0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
-  /// [deno-postgres@v0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
+  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
+  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
   static Future<QueryArrayResult<T>>
       queryArrayWithOptions<T extends List<dynamic>>(
     Object queryable,
@@ -38,8 +38,8 @@ class ClientCommon {
   // ): Promise<QueryArrayResult<T>>
   // https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_2
 
-  /// [deno-postgres@v0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
-  /// [deno-postgres@v0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
+  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
+  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
   static Future<QueryObjectResult<T>> queryObject<T>(
     Object queryable,
     String query, [
@@ -47,8 +47,8 @@ class ClientCommon {
   ]) =>
       _query('queryObject', queryable, query, arguments);
 
-  /// [deno-postgres@v0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
-  /// [deno-postgres@v0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
+  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
+  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
   static Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     Object queryable,
     QueryObjectOptions config,
@@ -61,7 +61,7 @@ class ClientCommon {
   //
   // [related issue](https://github.com/dart-lang/language/issues/1988).
   //
-  // [deno-postgres@v0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_2).
+  // [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_2).
   // Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
   //   List<String> query,
   //   List args,

--- a/lib/src/client_configuration.dart
+++ b/lib/src/client_configuration.dart
@@ -5,37 +5,37 @@ import 'package:deno_postgres_interop/src/connection_options.dart';
 import 'package:deno_postgres_interop/src/tls_options.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+/// [deno-postgres@v​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
 @JS()
 class ClientConfiguration {
-  /// [deno-postgres@​0.17.0/ClientConfiguration/applicationName](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_applicationName).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/applicationName](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_applicationName).
   external String get applicationName;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/connection](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_connection).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/connection](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_connection).
   external ConnectionOptions get connection;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/database](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_database).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/database](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_database).
   external String get database;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/hostname](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_hostname).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/hostname](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_hostname).
   external String get hostname;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/options](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_options).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/options](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_options).
   external Map<String, String> get options;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/password](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_password).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/password](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_password).
   external String? get password;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/port](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_port).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/port](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_port).
   external int get port;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/tls](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_tls).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/tls](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_tls).
   external TLSOptions get tls;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration/user](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_user).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/user](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_user).
   external String get user;
 
-  /// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
   factory ClientConfiguration({
     required String applicationName,
     required ConnectionOptions connection,
@@ -62,8 +62,8 @@ class ClientConfiguration {
       }) as ClientConfiguration;
 }
 
-/// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+/// [deno-postgres@v​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
 extension ClientConfigurationProps on ClientConfiguration {
-  /// [deno-postgres@​0.17.0/ClientConfiguration/host_type](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_host_type).
+  /// [deno-postgres@v​0.17.0/ClientConfiguration/host_type](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_host_type).
   Transport get hostType => Transport.parse(getProperty(this, 'host_type'));
 }

--- a/lib/src/client_configuration.dart
+++ b/lib/src/client_configuration.dart
@@ -5,37 +5,37 @@ import 'package:deno_postgres_interop/src/connection_options.dart';
 import 'package:deno_postgres_interop/src/tls_options.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@v0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+/// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
 @JS()
 class ClientConfiguration {
-  /// [deno-postgres@v0.17.0/ClientConfiguration/applicationName](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_applicationName).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/applicationName](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_applicationName).
   external String get applicationName;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/connection](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_connection).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/connection](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_connection).
   external ConnectionOptions get connection;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/database](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_database).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/database](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_database).
   external String get database;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/hostname](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_hostname).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/hostname](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_hostname).
   external String get hostname;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/options](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_options).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/options](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_options).
   external Map<String, String> get options;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/password](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_password).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/password](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_password).
   external String? get password;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/port](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_port).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/port](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_port).
   external int get port;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/tls](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_tls).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/tls](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_tls).
   external TLSOptions get tls;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration/user](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_user).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/user](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_user).
   external String get user;
 
-  /// [deno-postgres@v0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+  /// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
   factory ClientConfiguration({
     required String applicationName,
     required ConnectionOptions connection,
@@ -62,8 +62,8 @@ class ClientConfiguration {
       }) as ClientConfiguration;
 }
 
-/// [deno-postgres@v0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
+/// [deno-postgres@​0.17.0/ClientConfiguration](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration).
 extension ClientConfigurationProps on ClientConfiguration {
-  /// [deno-postgres@v0.17.0/ClientConfiguration/host_type](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_host_type).
+  /// [deno-postgres@​0.17.0/ClientConfiguration/host_type](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ClientConfiguration#prop_host_type).
   Transport get hostType => Transport.parse(getProperty(this, 'host_type'));
 }

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -5,25 +5,25 @@ import 'package:deno_postgres_interop/src/partial/partial_connection_options.dar
 import 'package:deno_postgres_interop/src/partial/partial_tls_options.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@v0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+/// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
 @JS()
 class ClientOptions {
-  /// [deno-postgres@v0.17.0/ClientOptions/applicationName](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName).
+  /// [deno-postgres@​0.17.0/ClientOptions/applicationName](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName).
   external String? get applicationName;
 
-  /// [deno-postgres@v0.17.0/ClientOptions/database](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_database).
+  /// [deno-postgres@​0.17.0/ClientOptions/database](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_database).
   external String? get database;
 
-  /// [deno-postgres@v0.17.0/ClientOptions/hostname](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_hostname).
+  /// [deno-postgres@​0.17.0/ClientOptions/hostname](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_hostname).
   external String? get hostname;
 
-  /// [deno-postgres@v0.17.0/ClientOptions/password](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_password).
+  /// [deno-postgres@​0.17.0/ClientOptions/password](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_password).
   external String? get password;
 
-  /// [deno-postgres@v0.17.0/ClientOptions/user](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName/user).
+  /// [deno-postgres@​0.17.0/ClientOptions/user](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName/user).
   external String? get user;
 
-  /// [deno-postgres@v0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+  /// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
   factory ClientOptions({
     String? applicationName,
     PartialConnectionOptions? connection,
@@ -64,12 +64,12 @@ class ClientOptions {
   }
 }
 
-/// [deno-postgres@v0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+/// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
 extension ClientOptionsProps on ClientOptions {
-  /// [deno-postgres@v0.17.0/ClientOptions/host_type](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_host_type).
+  /// [deno-postgres@​0.17.0/ClientOptions/host_type](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_host_type).
   Transport get hostType => Transport.parse(getProperty(this, 'host_type'));
 
-  /// [deno-postgres@v0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
+  /// [deno-postgres@​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
   ///
   /// Either this or [optionsMap] is null.
   String? get optionsString {
@@ -78,7 +78,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? prop : null;
   }
 
-  /// [deno-postgres@v0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
+  /// [deno-postgres@​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
   ///
   /// Either this or [optionsString] is null.
   Map<String, String>? get optionsMap {
@@ -87,7 +87,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? null : prop as Map<String, String>;
   }
 
-  /// [deno-postgres@v0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
+  /// [deno-postgres@​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
   ///
   /// Either this or [port] is null.
   String? get portString {
@@ -96,7 +96,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? prop : null;
   }
 
-  /// [deno-postgres@v0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
+  /// [deno-postgres@​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
   ///
   /// Either this or [portString] is null.
   int? get port {
@@ -105,7 +105,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is int ? prop : null;
   }
 
-  /// [deno-postgres@v0.17.0/ClientOptions/connection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_connection).
+  /// [deno-postgres@​0.17.0/ClientOptions/connection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_connection).
   PartialConnectionOptions? get connection {
     final map =
         dartify(getProperty(this, 'connection')) as Map<dynamic, dynamic>?;
@@ -113,7 +113,7 @@ extension ClientOptionsProps on ClientOptions {
     return map == null ? null : PartialConnectionOptions.fromMap(map);
   }
 
-  /// [deno-postgres@v0.17.0/ClientOptions/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_tls).
+  /// [deno-postgres@​0.17.0/ClientOptions/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_tls).
   PartialTLSOptions? get tls {
     final map =
         dartify(getProperty(this, 'connection')) as Map<dynamic, dynamic>?;

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -5,25 +5,25 @@ import 'package:deno_postgres_interop/src/partial/partial_connection_options.dar
 import 'package:deno_postgres_interop/src/partial/partial_tls_options.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+/// [deno-postgres@v​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
 @JS()
 class ClientOptions {
-  /// [deno-postgres@​0.17.0/ClientOptions/applicationName](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName).
+  /// [deno-postgres@v​0.17.0/ClientOptions/applicationName](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName).
   external String? get applicationName;
 
-  /// [deno-postgres@​0.17.0/ClientOptions/database](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_database).
+  /// [deno-postgres@v​0.17.0/ClientOptions/database](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_database).
   external String? get database;
 
-  /// [deno-postgres@​0.17.0/ClientOptions/hostname](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_hostname).
+  /// [deno-postgres@v​0.17.0/ClientOptions/hostname](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_hostname).
   external String? get hostname;
 
-  /// [deno-postgres@​0.17.0/ClientOptions/password](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_password).
+  /// [deno-postgres@v​0.17.0/ClientOptions/password](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_password).
   external String? get password;
 
-  /// [deno-postgres@​0.17.0/ClientOptions/user](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName/user).
+  /// [deno-postgres@v​0.17.0/ClientOptions/user](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_applicationName/user).
   external String? get user;
 
-  /// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+  /// [deno-postgres@v​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
   factory ClientOptions({
     String? applicationName,
     PartialConnectionOptions? connection,
@@ -64,12 +64,12 @@ class ClientOptions {
   }
 }
 
-/// [deno-postgres@​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
+/// [deno-postgres@v​0.17.0/ClientOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions).
 extension ClientOptionsProps on ClientOptions {
-  /// [deno-postgres@​0.17.0/ClientOptions/host_type](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_host_type).
+  /// [deno-postgres@v​0.17.0/ClientOptions/host_type](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_host_type).
   Transport get hostType => Transport.parse(getProperty(this, 'host_type'));
 
-  /// [deno-postgres@​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
+  /// [deno-postgres@v​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
   ///
   /// Either this or [optionsMap] is null.
   String? get optionsString {
@@ -78,7 +78,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? prop : null;
   }
 
-  /// [deno-postgres@​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
+  /// [deno-postgres@v​0.17.0/ClientOptions/options](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_options).
   ///
   /// Either this or [optionsString] is null.
   Map<String, String>? get optionsMap {
@@ -87,7 +87,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? null : prop as Map<String, String>;
   }
 
-  /// [deno-postgres@​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
+  /// [deno-postgres@v​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
   ///
   /// Either this or [port] is null.
   String? get portString {
@@ -96,7 +96,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is String ? prop : null;
   }
 
-  /// [deno-postgres@​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
+  /// [deno-postgres@v​0.17.0/ClientOptions/port](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_port).
   ///
   /// Either this or [portString] is null.
   int? get port {
@@ -105,7 +105,7 @@ extension ClientOptionsProps on ClientOptions {
     return prop is int ? prop : null;
   }
 
-  /// [deno-postgres@​0.17.0/ClientOptions/connection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_connection).
+  /// [deno-postgres@v​0.17.0/ClientOptions/connection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_connection).
   PartialConnectionOptions? get connection {
     final map =
         dartify(getProperty(this, 'connection')) as Map<dynamic, dynamic>?;
@@ -113,7 +113,7 @@ extension ClientOptionsProps on ClientOptions {
     return map == null ? null : PartialConnectionOptions.fromMap(map);
   }
 
-  /// [deno-postgres@​0.17.0/ClientOptions/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_tls).
+  /// [deno-postgres@v​0.17.0/ClientOptions/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=ClientOptions#prop_tls).
   PartialTLSOptions? get tls {
     final map =
         dartify(getProperty(this, 'connection')) as Map<dynamic, dynamic>?;

--- a/lib/src/column.dart
+++ b/lib/src/column.dart
@@ -1,28 +1,28 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+/// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
 @JS()
 class Column {
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external String get name;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get tableOid;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get index;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get typeOid;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get columnLength;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get typeModifier;
 
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column#ctor_0).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column#ctor_0).
   factory Column({
     required String name,
     required int tableOid,
@@ -43,9 +43,9 @@ class Column {
       ]);
 }
 
-/// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+/// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
 extension ColumnProps on Column {
-  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@v​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   ColumnFormat get format => ColumnFormat.values
       .firstWhere((e) => e.id == getProperty(this, 'format'));
 }

--- a/lib/src/column.dart
+++ b/lib/src/column.dart
@@ -1,28 +1,28 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+/// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
 @JS()
 class Column {
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external String get name;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get tableOid;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get index;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get typeOid;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get columnLength;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   external int get typeModifier;
 
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column#ctor_0).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column#ctor_0).
   factory Column({
     required String name,
     required int tableOid,
@@ -43,9 +43,9 @@ class Column {
       ]);
 }
 
-/// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+/// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
 extension ColumnProps on Column {
-  /// [deno-postgres@v0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
+  /// [deno-postgres@​0.17.0/Column](https://deno.land/x/postgres@v0.17.0/query/decode.ts?s=Column).
   ColumnFormat get format => ColumnFormat.values
       .firstWhere((e) => e.id == getProperty(this, 'format'));
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -8,13 +8,13 @@ import 'package:deno_postgres_interop/src/query_result.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
+/// [deno-postgres@v​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
 @JS()
 class Connection {
-  /// [deno-postgres@​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_pid).
+  /// [deno-postgres@v​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_pid).
   external int get pid;
 
-  /// [deno-postgres@​0.17.0/Connection/constructor](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#ctor_0).
+  /// [deno-postgres@v​0.17.0/Connection/constructor](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#ctor_0).
   factory Connection({
     required ClientConfiguration connectionParams,
     required Future<void> Function() disconnectionCallback,
@@ -25,26 +25,26 @@ class Connection {
       );
 }
 
-/// [deno-postgres@​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
+/// [deno-postgres@v​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
 extension ConnectionProps on Connection {
-  /// [deno-postgres@​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#prop_connected).
+  /// [deno-postgres@v​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#prop_connected).
   bool get isConnected => getProperty(this, 'connected');
 
-  /// [deno-postgres@​0.17.0/Connection/tls](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_tls).
+  /// [deno-postgres@v​0.17.0/Connection/tls](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_tls).
   bool get isCarriedOverTLS => getProperty(this, 'tls');
 
-  /// [deno-postgres@​0.17.0/Connection/transport](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_transport).
+  /// [deno-postgres@v​0.17.0/Connection/transport](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_transport).
   Transport get transport => Transport.parse(getProperty(this, 'transport'));
 
-  /// [deno-postgres@​0.17.0/Connection/end](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_end_0).
+  /// [deno-postgres@v​0.17.0/Connection/end](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_0).
-  /// [deno-postgres@​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_1).
+  /// [deno-postgres@v​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_0).
+  /// [deno-postgres@v​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_1).
   Future<T> queryArray<T extends QueryResult>(Query query) =>
       callFutureMethod(this, 'query', [query]);
 
-  /// [deno-postgres@​0.17.0/Connection/startup](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_startup_0).
+  /// [deno-postgres@v​0.17.0/Connection/startup](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_startup_0).
   Future<void> startup({required bool isReconnection}) =>
       callFutureMethod(this, 'startup', [isReconnection]);
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -8,13 +8,13 @@ import 'package:deno_postgres_interop/src/query_result.dart';
 import 'package:deno_postgres_interop/src/transport.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
+/// [deno-postgres@​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
 @JS()
 class Connection {
-  /// [deno-postgres@v0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_pid).
+  /// [deno-postgres@​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_pid).
   external int get pid;
 
-  /// [deno-postgres@v0.17.0/Connection/constructor](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#ctor_0).
+  /// [deno-postgres@​0.17.0/Connection/constructor](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#ctor_0).
   factory Connection({
     required ClientConfiguration connectionParams,
     required Future<void> Function() disconnectionCallback,
@@ -25,26 +25,26 @@ class Connection {
       );
 }
 
-/// [deno-postgres@v0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
+/// [deno-postgres@​0.17.0/Connection](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection).
 extension ConnectionProps on Connection {
-  /// [deno-postgres@v0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#prop_connected).
+  /// [deno-postgres@​0.17.0/Connection/connected](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#prop_connected).
   bool get isConnected => getProperty(this, 'connected');
 
-  /// [deno-postgres@v0.17.0/Connection/tls](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_tls).
+  /// [deno-postgres@​0.17.0/Connection/tls](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_tls).
   bool get isCarriedOverTLS => getProperty(this, 'tls');
 
-  /// [deno-postgres@v0.17.0/Connection/transport](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_transport).
+  /// [deno-postgres@​0.17.0/Connection/transport](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#accessor_transport).
   Transport get transport => Transport.parse(getProperty(this, 'transport'));
 
-  /// [deno-postgres@v0.17.0/Connection/end](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_end_0).
+  /// [deno-postgres@​0.17.0/Connection/end](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@v0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_0).
-  /// [deno-postgres@v0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_1).
+  /// [deno-postgres@​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_0).
+  /// [deno-postgres@​0.17.0/Connection/query](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_query_1).
   Future<T> queryArray<T extends QueryResult>(Query query) =>
       callFutureMethod(this, 'query', [query]);
 
-  /// [deno-postgres@v0.17.0/Connection/startup](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_startup_0).
+  /// [deno-postgres@​0.17.0/Connection/startup](https://deno.land/x/postgres@v0.17.0/connection/connection.ts?s=Connection#method_startup_0).
   Future<void> startup({required bool isReconnection}) =>
       callFutureMethod(this, 'startup', [isReconnection]);
 }

--- a/lib/src/connection_options.dart
+++ b/lib/src/connection_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/partial/partial_connection_options.dart';
 
-/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 @JS()
 class ConnectionOptions {
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
   external int get attempts;
 
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
   factory ConnectionOptions({
     required int attempts,
     int Function(int previousInterval)? nextInterval,
@@ -25,9 +25,9 @@ class ConnectionOptions {
   }
 }
 
-/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 extension ConnectionOptionsProps on ConnectionOptions {
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [interval] is null.
   int Function(int previousInterval)? get nextInterval {
@@ -36,7 +36,7 @@ extension ConnectionOptionsProps on ConnectionOptions {
     return prop is int ? null : prop as int Function(int previousInterval);
   }
 
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [nextInterval] is null.
   int? get interval {

--- a/lib/src/connection_options.dart
+++ b/lib/src/connection_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/partial/partial_connection_options.dart';
 
-/// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 @JS()
 class ConnectionOptions {
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
   external int get attempts;
 
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
   factory ConnectionOptions({
     required int attempts,
     int Function(int previousInterval)? nextInterval,
@@ -25,9 +25,9 @@ class ConnectionOptions {
   }
 }
 
-/// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 extension ConnectionOptionsProps on ConnectionOptions {
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [interval] is null.
   int Function(int previousInterval)? get nextInterval {
@@ -36,7 +36,7 @@ extension ConnectionOptionsProps on ConnectionOptions {
     return prop is int ? null : prop as int Function(int previousInterval);
   }
 
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [nextInterval] is null.
   int? get interval {

--- a/lib/src/encoded_arg.dart
+++ b/lib/src/encoded_arg.dart
@@ -1,2 +1,2 @@
-/// [deno-postgres@v0.17.0/EncodedArg](https://deno.land/x/postgres@v0.17.0/query/encode.ts?s=EncodedArg).
+/// [deno-postgres@​0.17.0/EncodedArg](https://deno.land/x/postgres@v0.17.0/query/encode.ts?s=EncodedArg).
 typedef EncodedArg = dynamic;

--- a/lib/src/encoded_arg.dart
+++ b/lib/src/encoded_arg.dart
@@ -1,2 +1,2 @@
-/// [deno-postgres@​0.17.0/EncodedArg](https://deno.land/x/postgres@v0.17.0/query/encode.ts?s=EncodedArg).
+/// [deno-postgres@v​0.17.0/EncodedArg](https://deno.land/x/postgres@v0.17.0/query/encode.ts?s=EncodedArg).
 typedef EncodedArg = dynamic;

--- a/lib/src/errors/connection_error.dart
+++ b/lib/src/errors/connection_error.dart
@@ -2,6 +2,6 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 
-/// [deno-postgres@v0.17.0/ConnectionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionError).
+/// [deno-postgres@​0.17.0/ConnectionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionError).
 @JS('Error')
 class ConnectionError extends JSError {}

--- a/lib/src/errors/connection_error.dart
+++ b/lib/src/errors/connection_error.dart
@@ -2,6 +2,6 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 
-/// [deno-postgres@​0.17.0/ConnectionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionError).
+/// [deno-postgres@v​0.17.0/ConnectionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionError).
 @JS('Error')
 class ConnectionError extends JSError {}

--- a/lib/src/errors/connection_params_error.dart
+++ b/lib/src/errors/connection_params_error.dart
@@ -2,6 +2,6 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 
-/// [deno-postgres@​0.17.0/ConnectionParamsError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionParamsError).
+/// [deno-postgres@v​0.17.0/ConnectionParamsError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionParamsError).
 @JS('Error')
 class ConnectionParamsError extends JSError {}

--- a/lib/src/errors/connection_params_error.dart
+++ b/lib/src/errors/connection_params_error.dart
@@ -2,6 +2,6 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 
-/// [deno-postgres@v0.17.0/ConnectionParamsError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionParamsError).
+/// [deno-postgres@​0.17.0/ConnectionParamsError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=ConnectionParamsError).
 @JS('Error')
 class ConnectionParamsError extends JSError {}

--- a/lib/src/errors/postgres_error.dart
+++ b/lib/src/errors/postgres_error.dart
@@ -3,9 +3,9 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 import 'package:deno_postgres_interop/src/notice.dart';
 
-/// [deno-postgres@v0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
+/// [deno-postgres@​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
 @JS()
 class PostgresError extends JSError {
-  /// [deno-postgres@v0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=PostgresError#prop_fields).
+  /// [deno-postgres@​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=PostgresError#prop_fields).
   external Notice get fields;
 }

--- a/lib/src/errors/postgres_error.dart
+++ b/lib/src/errors/postgres_error.dart
@@ -3,9 +3,9 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/errors/js_error.dart';
 import 'package:deno_postgres_interop/src/notice.dart';
 
-/// [deno-postgres@​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
+/// [deno-postgres@v​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
 @JS()
 class PostgresError extends JSError {
-  /// [deno-postgres@​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=PostgresError#prop_fields).
+  /// [deno-postgres@v​0.17.0/PostgresError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=PostgresError#prop_fields).
   external Notice get fields;
 }

--- a/lib/src/errors/transaction_error.dart
+++ b/lib/src/errors/transaction_error.dart
@@ -2,11 +2,11 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/postgres_error.dart';
 
-/// [deno-postgres@v0.17.0/TransactionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
+/// [deno-postgres@​0.17.0/TransactionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
 @JS()
 class TransactionError {
   /// [js/Error/cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).
-  /// [deno-postgres@v0.17.0/TransactionError/constructor](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError#ctor_0).
+  /// [deno-postgres@​0.17.0/TransactionError/constructor](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError#ctor_0).
   external PostgresError get cause;
 
   /// [js/Error/message](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message).

--- a/lib/src/errors/transaction_error.dart
+++ b/lib/src/errors/transaction_error.dart
@@ -2,11 +2,11 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/errors/postgres_error.dart';
 
-/// [deno-postgres@​0.17.0/TransactionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
+/// [deno-postgres@v​0.17.0/TransactionError](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError).
 @JS()
 class TransactionError {
   /// [js/Error/cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).
-  /// [deno-postgres@​0.17.0/TransactionError/constructor](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError#ctor_0).
+  /// [deno-postgres@v​0.17.0/TransactionError/constructor](https://deno.land/x/postgres@v0.17.0/client/error.ts?s=TransactionError#ctor_0).
   external PostgresError get cause;
 
   /// [js/Error/message](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message).

--- a/lib/src/notice.dart
+++ b/lib/src/notice.dart
@@ -1,61 +1,61 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@v0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
+/// [deno-postgres@​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
 @JS()
 class Notice {
-  /// [deno-postgres@v0.17.0/Notice/severity](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_severity).
+  /// [deno-postgres@​0.17.0/Notice/severity](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_severity).
   external String get severity;
 
-  /// [deno-postgres@v0.17.0/Notice/code](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_code).
+  /// [deno-postgres@​0.17.0/Notice/code](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_code).
   external String get code;
 
-  /// [deno-postgres@v0.17.0/Notice/message](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_message).
+  /// [deno-postgres@​0.17.0/Notice/message](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_message).
   external String get message;
 
-  /// [deno-postgres@v0.17.0/Notice/detail](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_detail).
+  /// [deno-postgres@​0.17.0/Notice/detail](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_detail).
   external String? get detail;
 
-  /// [deno-postgres@v0.17.0/Notice/hint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_hint).
+  /// [deno-postgres@​0.17.0/Notice/hint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_hint).
   external String? get hint;
 
-  /// [deno-postgres@v0.17.0/Notice/position](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_position).
+  /// [deno-postgres@​0.17.0/Notice/position](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_position).
   external String? get position;
 
-  /// [deno-postgres@v0.17.0/Notice/internalPosition](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalPosition).
+  /// [deno-postgres@​0.17.0/Notice/internalPosition](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalPosition).
   external String? get internalPosition;
 
-  /// [deno-postgres@v0.17.0/Notice/internalQuery](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalQuery).
+  /// [deno-postgres@​0.17.0/Notice/internalQuery](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalQuery).
   external String? get internalQuery;
 
-  /// [deno-postgres@v0.17.0/Notice/where](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_where).
+  /// [deno-postgres@​0.17.0/Notice/where](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_where).
   external String? get where;
 
-  /// [deno-postgres@v0.17.0/Notice/schema](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_schema).
+  /// [deno-postgres@​0.17.0/Notice/schema](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_schema).
   external String? get schema;
 
-  /// [deno-postgres@v0.17.0/Notice/table](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_table).
+  /// [deno-postgres@​0.17.0/Notice/table](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_table).
   external String? get table;
 
-  /// [deno-postgres@v0.17.0/Notice/column](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_column).
+  /// [deno-postgres@​0.17.0/Notice/column](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_column).
   external String? get column;
 
-  /// [deno-postgres@v0.17.0/Notice/dataType](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_dataType).
+  /// [deno-postgres@​0.17.0/Notice/dataType](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_dataType).
   external String? get dataType;
 
-  /// [deno-postgres@v0.17.0/Notice/constraint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_constraint).
+  /// [deno-postgres@​0.17.0/Notice/constraint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_constraint).
   external String? get constraint;
 
-  /// [deno-postgres@v0.17.0/Notice/file](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_file).
+  /// [deno-postgres@​0.17.0/Notice/file](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_file).
   external String? get file;
 
-  /// [deno-postgres@v0.17.0/Notice/line](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_line).
+  /// [deno-postgres@​0.17.0/Notice/line](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_line).
   external String? get line;
 
-  /// [deno-postgres@v0.17.0/Notice/routine](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_routine).
+  /// [deno-postgres@​0.17.0/Notice/routine](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_routine).
   external String? get routine;
 
-  /// [deno-postgres@v0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
+  /// [deno-postgres@​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
   factory Notice({
     required String severity,
     required String code,

--- a/lib/src/notice.dart
+++ b/lib/src/notice.dart
@@ -1,61 +1,61 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
+/// [deno-postgres@v​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
 @JS()
 class Notice {
-  /// [deno-postgres@​0.17.0/Notice/severity](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_severity).
+  /// [deno-postgres@v​0.17.0/Notice/severity](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_severity).
   external String get severity;
 
-  /// [deno-postgres@​0.17.0/Notice/code](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_code).
+  /// [deno-postgres@v​0.17.0/Notice/code](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_code).
   external String get code;
 
-  /// [deno-postgres@​0.17.0/Notice/message](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_message).
+  /// [deno-postgres@v​0.17.0/Notice/message](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_message).
   external String get message;
 
-  /// [deno-postgres@​0.17.0/Notice/detail](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_detail).
+  /// [deno-postgres@v​0.17.0/Notice/detail](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_detail).
   external String? get detail;
 
-  /// [deno-postgres@​0.17.0/Notice/hint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_hint).
+  /// [deno-postgres@v​0.17.0/Notice/hint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_hint).
   external String? get hint;
 
-  /// [deno-postgres@​0.17.0/Notice/position](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_position).
+  /// [deno-postgres@v​0.17.0/Notice/position](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_position).
   external String? get position;
 
-  /// [deno-postgres@​0.17.0/Notice/internalPosition](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalPosition).
+  /// [deno-postgres@v​0.17.0/Notice/internalPosition](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalPosition).
   external String? get internalPosition;
 
-  /// [deno-postgres@​0.17.0/Notice/internalQuery](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalQuery).
+  /// [deno-postgres@v​0.17.0/Notice/internalQuery](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_internalQuery).
   external String? get internalQuery;
 
-  /// [deno-postgres@​0.17.0/Notice/where](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_where).
+  /// [deno-postgres@v​0.17.0/Notice/where](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_where).
   external String? get where;
 
-  /// [deno-postgres@​0.17.0/Notice/schema](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_schema).
+  /// [deno-postgres@v​0.17.0/Notice/schema](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_schema).
   external String? get schema;
 
-  /// [deno-postgres@​0.17.0/Notice/table](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_table).
+  /// [deno-postgres@v​0.17.0/Notice/table](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_table).
   external String? get table;
 
-  /// [deno-postgres@​0.17.0/Notice/column](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_column).
+  /// [deno-postgres@v​0.17.0/Notice/column](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_column).
   external String? get column;
 
-  /// [deno-postgres@​0.17.0/Notice/dataType](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_dataType).
+  /// [deno-postgres@v​0.17.0/Notice/dataType](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_dataType).
   external String? get dataType;
 
-  /// [deno-postgres@​0.17.0/Notice/constraint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_constraint).
+  /// [deno-postgres@v​0.17.0/Notice/constraint](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_constraint).
   external String? get constraint;
 
-  /// [deno-postgres@​0.17.0/Notice/file](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_file).
+  /// [deno-postgres@v​0.17.0/Notice/file](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_file).
   external String? get file;
 
-  /// [deno-postgres@​0.17.0/Notice/line](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_line).
+  /// [deno-postgres@v​0.17.0/Notice/line](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_line).
   external String? get line;
 
-  /// [deno-postgres@​0.17.0/Notice/routine](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_routine).
+  /// [deno-postgres@v​0.17.0/Notice/routine](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice#prop_routine).
   external String? get routine;
 
-  /// [deno-postgres@​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
+  /// [deno-postgres@v​0.17.0/Notice](https://deno.land/x/postgres@v0.17.0/connection/message.ts?s=Notice).
   factory Notice({
     required String severity,
     required String code,

--- a/lib/src/partial/partial_connection_options.dart
+++ b/lib/src/partial/partial_connection_options.dart
@@ -1,14 +1,14 @@
-/// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 class PartialConnectionOptions {
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
   final int? attempts;
 
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [interval] is null.
   final int Function(int previousInterval)? nextInterval;
 
-  /// [deno-postgres@v0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [nextInterval] is null.
   final int? interval;

--- a/lib/src/partial/partial_connection_options.dart
+++ b/lib/src/partial/partial_connection_options.dart
@@ -1,14 +1,14 @@
-/// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
+/// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions).
 class PartialConnectionOptions {
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_attempts).
   final int? attempts;
 
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [interval] is null.
   final int Function(int previousInterval)? nextInterval;
 
-  /// [deno-postgres@​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
+  /// [deno-postgres@v​0.17.0/ConnectionOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=ConnectionOptions#prop_interval).
   ///
   /// Either this or [nextInterval] is null.
   final int? interval;

--- a/lib/src/partial/partial_tls_options.dart
+++ b/lib/src/partial/partial_tls_options.dart
@@ -1,12 +1,12 @@
-/// [deno-postgres@v0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions).
+/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions).
 class PartialTLSOptions {
-  /// [deno-postgres@v0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enabled).
+  /// [deno-postgres@​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enabled).
   final bool? isEnabled;
 
-  /// [deno-postgres@v0.17.0/TLSOptions/enfroce](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enfroce).
+  /// [deno-postgres@​0.17.0/TLSOptions/enfroce](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enfroce).
   final bool? isEnforced;
 
-  /// [deno-postgres@v0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_caCertificates).
+  /// [deno-postgres@​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_caCertificates).
   final List<String>? caCertificates;
 
   /// constructor.

--- a/lib/src/partial/partial_tls_options.dart
+++ b/lib/src/partial/partial_tls_options.dart
@@ -1,12 +1,12 @@
-/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions).
+/// [deno-postgres@v​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions).
 class PartialTLSOptions {
-  /// [deno-postgres@​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enabled).
+  /// [deno-postgres@v​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enabled).
   final bool? isEnabled;
 
-  /// [deno-postgres@​0.17.0/TLSOptions/enfroce](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enfroce).
+  /// [deno-postgres@v​0.17.0/TLSOptions/enfroce](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_enfroce).
   final bool? isEnforced;
 
-  /// [deno-postgres@​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_caCertificates).
+  /// [deno-postgres@v​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/connection/connection_params.ts?s=TLSOptions#prop_caCertificates).
   final List<String>? caCertificates;
 
   /// constructor.

--- a/lib/src/pool.dart
+++ b/lib/src/pool.dart
@@ -6,10 +6,10 @@ import 'package:deno_postgres_interop/src/pool_client.dart';
 import 'package:deno_postgres_interop/src/undefined.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
+/// [deno-postgres@v​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
 @JS()
 class Pool {
-  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@v​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool({
     required int size,
     bool? lazy,
@@ -20,7 +20,7 @@ class Pool {
         if (lazy != null) lazy,
       ]);
 
-  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@v​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool.withOptions({
     required ClientOptions connectionParams,
     required int size,
@@ -32,7 +32,7 @@ class Pool {
         if (lazy != null) lazy,
       ]);
 
-  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@v​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool.withString({
     required String connectionString,
     required int size,
@@ -45,21 +45,21 @@ class Pool {
       ]);
 }
 
-/// [deno-postgres@​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
+/// [deno-postgres@v​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
 extension PoolProps on Pool {
-  /// [deno-postgres@​0.17.0/Pool/size](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_size).
+  /// [deno-postgres@v​0.17.0/Pool/size](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_size).
   int get connectionsCount => getProperty(this, 'size');
 
-  /// [deno-postgres@​0.17.0/Pool/available](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_available).
+  /// [deno-postgres@v​0.17.0/Pool/available](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_available).
   int get openConnectionsCount => getProperty(this, 'available');
 
-  /// [deno-postgres@​0.17.0/Pool/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_connect_0).
+  /// [deno-postgres@v​0.17.0/Pool/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_connect_0).
   Future<PoolClient> connect() => callFutureMethod(this, 'connect');
 
-  /// [deno-postgres@​0.17.0/Pool/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_end_0).
+  /// [deno-postgres@v​0.17.0/Pool/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@​0.17.0/Pool/initialized](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_initialized_0).
+  /// [deno-postgres@v​0.17.0/Pool/initialized](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_initialized_0).
   Future<int> initializedConnectionsCount() =>
       callFutureMethod(this, 'initialized');
 }

--- a/lib/src/pool.dart
+++ b/lib/src/pool.dart
@@ -6,10 +6,10 @@ import 'package:deno_postgres_interop/src/pool_client.dart';
 import 'package:deno_postgres_interop/src/undefined.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
+/// [deno-postgres@​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
 @JS()
 class Pool {
-  /// [deno-postgres@v0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool({
     required int size,
     bool? lazy,
@@ -20,7 +20,7 @@ class Pool {
         if (lazy != null) lazy,
       ]);
 
-  /// [deno-postgres@v0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool.withOptions({
     required ClientOptions connectionParams,
     required int size,
@@ -32,7 +32,7 @@ class Pool {
         if (lazy != null) lazy,
       ]);
 
-  /// [deno-postgres@v0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
+  /// [deno-postgres@​0.17.0/Pool/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#ctor_0).
   factory Pool.withString({
     required String connectionString,
     required int size,
@@ -45,21 +45,21 @@ class Pool {
       ]);
 }
 
-/// [deno-postgres@v0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
+/// [deno-postgres@​0.17.0/Pool](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool).
 extension PoolProps on Pool {
-  /// [deno-postgres@v0.17.0/Pool/size](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_size).
+  /// [deno-postgres@​0.17.0/Pool/size](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_size).
   int get connectionsCount => getProperty(this, 'size');
 
-  /// [deno-postgres@v0.17.0/Pool/available](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_available).
+  /// [deno-postgres@​0.17.0/Pool/available](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#prop_available).
   int get openConnectionsCount => getProperty(this, 'available');
 
-  /// [deno-postgres@v0.17.0/Pool/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_connect_0).
+  /// [deno-postgres@​0.17.0/Pool/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_connect_0).
   Future<PoolClient> connect() => callFutureMethod(this, 'connect');
 
-  /// [deno-postgres@v0.17.0/Pool/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_end_0).
+  /// [deno-postgres@​0.17.0/Pool/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@v0.17.0/Pool/initialized](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_initialized_0).
+  /// [deno-postgres@​0.17.0/Pool/initialized](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Pool#method_initialized_0).
   Future<int> initializedConnectionsCount() =>
       callFutureMethod(this, 'initialized');
 }

--- a/lib/src/pool_client.dart
+++ b/lib/src/pool_client.dart
@@ -3,15 +3,15 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/client_configuration.dart';
 import 'package:deno_postgres_interop/src/query_client.dart';
 
-/// [deno-postgres@​0.17.0/PoolClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient).
+/// [deno-postgres@v​0.17.0/PoolClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient).
 @JS()
 class PoolClient extends QueryClient {
-  /// [deno-postgres@​0.17.0/PoolClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#ctor_0).
+  /// [deno-postgres@v​0.17.0/PoolClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#ctor_0).
   external factory PoolClient(
     ClientConfiguration config,
     void Function() releaseCallback,
   );
 
-  /// [deno-postgres@​0.17.0/PoolClient/constructor/release](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#method_release_0).
+  /// [deno-postgres@v​0.17.0/PoolClient/constructor/release](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#method_release_0).
   external void release();
 }

--- a/lib/src/pool_client.dart
+++ b/lib/src/pool_client.dart
@@ -3,15 +3,15 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/client_configuration.dart';
 import 'package:deno_postgres_interop/src/query_client.dart';
 
-/// [deno-postgres@v0.17.0/PoolClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient).
+/// [deno-postgres@​0.17.0/PoolClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient).
 @JS()
 class PoolClient extends QueryClient {
-  /// [deno-postgres@v0.17.0/PoolClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#ctor_0).
+  /// [deno-postgres@​0.17.0/PoolClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#ctor_0).
   external factory PoolClient(
     ClientConfiguration config,
     void Function() releaseCallback,
   );
 
-  /// [deno-postgres@v0.17.0/PoolClient/constructor/release](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#method_release_0).
+  /// [deno-postgres@​0.17.0/PoolClient/constructor/release](https://deno.land/x/postgres@v0.17.0/mod.ts?s=PoolClient#method_release_0).
   external void release();
 }

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -6,20 +6,20 @@ import 'package:deno_postgres_interop/src/encoded_arg.dart';
 import 'package:deno_postgres_interop/src/query_object_options.dart';
 import 'package:deno_postgres_interop/src/result_type.dart';
 
-/// [deno-postgres@​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
+/// [deno-postgres@v​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
 @JS()
 class Query {
-  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_args).
+  /// [deno-postgres@v​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_args).
   external List<EncodedArg> args;
 
-  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_fields).
+  /// [deno-postgres@v​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_fields).
   external List<String>? get fields;
 
-  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_text).
+  /// [deno-postgres@v​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_text).
   external String get text;
 
-  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_0).
-  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
+  /// [deno-postgres@v​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_0).
+  /// [deno-postgres@v​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
   factory Query.withConfig({
     required QueryObjectOptions config,
     required ResultType resultType,
@@ -27,8 +27,8 @@ class Query {
   }) =>
       callConstructor('Query', [config, resultType, args]) as Query;
 
-  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_1).
-  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
+  /// [deno-postgres@v​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_1).
+  /// [deno-postgres@v​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
   factory Query.withArgs({
     required String text,
     required ResultType resultType,
@@ -37,12 +37,12 @@ class Query {
       callConstructor('Query', [text, resultType, args]) as Query;
 }
 
-/// [deno-postgres@​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
+/// [deno-postgres@v​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
 extension QueryProps on Query {
-  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_camelcase).
+  /// [deno-postgres@v​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_camelcase).
   bool? get isCamelCase => getProperty(this, 'camelcase');
 
-  /// [deno-postgres@​0.17.0/Query/result_type](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_result_type).
+  /// [deno-postgres@v​0.17.0/Query/result_type](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_result_type).
   ResultType get resultType =>
       ResultType.values[getProperty(this, 'result_type')];
 }

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -6,20 +6,20 @@ import 'package:deno_postgres_interop/src/encoded_arg.dart';
 import 'package:deno_postgres_interop/src/query_object_options.dart';
 import 'package:deno_postgres_interop/src/result_type.dart';
 
-/// [deno-postgres@v0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
+/// [deno-postgres@​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
 @JS()
 class Query {
-  /// [deno-postgres@v0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_args).
+  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_args).
   external List<EncodedArg> args;
 
-  /// [deno-postgres@v0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_fields).
+  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_fields).
   external List<String>? get fields;
 
-  /// [deno-postgres@v0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_text).
+  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_text).
   external String get text;
 
-  /// [deno-postgres@v0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_0).
-  /// [deno-postgres@v0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
+  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_0).
+  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
   factory Query.withConfig({
     required QueryObjectOptions config,
     required ResultType resultType,
@@ -27,8 +27,8 @@ class Query {
   }) =>
       callConstructor('Query', [config, resultType, args]) as Query;
 
-  /// [deno-postgres@v0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_1).
-  /// [deno-postgres@v0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
+  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_1).
+  /// [deno-postgres@​0.17.0/Query/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#ctor_2).
   factory Query.withArgs({
     required String text,
     required ResultType resultType,
@@ -37,12 +37,12 @@ class Query {
       callConstructor('Query', [text, resultType, args]) as Query;
 }
 
-/// [deno-postgres@v0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
+/// [deno-postgres@​0.17.0/Query](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query).
 extension QueryProps on Query {
-  /// [deno-postgres@v0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_camelcase).
+  /// [deno-postgres@​0.17.0/Query/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_camelcase).
   bool? get isCamelCase => getProperty(this, 'camelcase');
 
-  /// [deno-postgres@v0.17.0/Query/result_type](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_result_type).
+  /// [deno-postgres@​0.17.0/Query/result_type](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=Query#prop_result_type).
   ResultType get resultType =>
       ResultType.values[getProperty(this, 'result_type')];
 }

--- a/lib/src/query_array_result.dart
+++ b/lib/src/query_array_result.dart
@@ -3,12 +3,12 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/query_result.dart';
 
-/// [deno-postgres@v0.17.0/QueryArrayResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult).
+/// [deno-postgres@​0.17.0/QueryArrayResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult).
 @JS()
 class QueryArrayResult<T extends List<dynamic>> extends QueryResult {
-  /// [deno-postgres@v0.17.0/QueryArrayResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult#prop_rows).
+  /// [deno-postgres@​0.17.0/QueryArrayResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult#prop_rows).
   external List<T> get rows;
 
-  /// [deno-postgres@v0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryArrayResult(Query query);
 }

--- a/lib/src/query_array_result.dart
+++ b/lib/src/query_array_result.dart
@@ -3,12 +3,12 @@ import 'dart:js_interop';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/query_result.dart';
 
-/// [deno-postgres@​0.17.0/QueryArrayResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult).
+/// [deno-postgres@v​0.17.0/QueryArrayResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult).
 @JS()
 class QueryArrayResult<T extends List<dynamic>> extends QueryResult {
-  /// [deno-postgres@​0.17.0/QueryArrayResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult#prop_rows).
+  /// [deno-postgres@v​0.17.0/QueryArrayResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryArrayResult#prop_rows).
   external List<T> get rows;
 
-  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryArrayResult(Query query);
 }

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -11,34 +11,34 @@ import 'package:deno_postgres_interop/src/transaction.dart';
 import 'package:deno_postgres_interop/src/transaction_options.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
+/// [deno-postgres@​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
 @JS()
 class QueryClient {
-  /// [deno-postgres@v0.17.0/QueryClient/session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_session).
+  /// [deno-postgres@​0.17.0/QueryClient/session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_session).
   external Session get session;
 
-  /// [deno-postgres@v0.17.0/QueryClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#ctor_0).
+  /// [deno-postgres@​0.17.0/QueryClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#ctor_0).
   external factory QueryClient(Connection connection);
 }
 
-/// [deno-postgres@v0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
+/// [deno-postgres@​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
 extension QueryClientProps on QueryClient {
-  /// [deno-postgres@v0.17.0/QueryClient/connected](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_connected).
+  /// [deno-postgres@​0.17.0/QueryClient/connected](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_connected).
   bool get isConnected => getProperty(this, 'connected');
 
-  /// [deno-postgres@v0.17.0/QueryClient/closeConnection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_closeConnection_0).
+  /// [deno-postgres@​0.17.0/QueryClient/closeConnection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_closeConnection_0).
   Future<void> closeConnection() => callFutureMethod(this, 'closeConnection');
 
-  /// [deno-postgres@v0.17.0/QueryClient/resetSessionMetadata](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_resetSessionMetadata_0).
+  /// [deno-postgres@​0.17.0/QueryClient/resetSessionMetadata](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_resetSessionMetadata_0).
   void resetSessionMetadata() => callMethod(this, 'resetSessionMetadata', []);
 
-  /// [deno-postgres@v0.17.0/QueryClient/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_connect_0).
+  /// [deno-postgres@​0.17.0/QueryClient/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_connect_0).
   Future<void> connect() => callFutureMethod(this, 'connect');
 
-  /// [deno-postgres@v0.17.0/QueryClient/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_end_0).
+  /// [deno-postgres@​0.17.0/QueryClient/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@v0.17.0/QueryClient/createTransaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_createTransaction_0).
+  /// [deno-postgres@​0.17.0/QueryClient/createTransaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_createTransaction_0).
   Transaction createTransaction(String name, [TransactionOptions? options]) =>
       callMethod(
         this,
@@ -65,27 +65,27 @@ extension QueryClientProps on QueryClient {
     return result;
   }
 
-  /// [deno-postgres@v0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
+  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
   Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     String query, [
     QueryArguments? args,
   ]) =>
       ClientCommon.queryArray(this, query, args);
 
-  /// [deno-postgres@v0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
+  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
   Future<QueryArrayResult<T>> queryArrayWithOptions<T extends List<dynamic>>(
     QueryObjectOptions config,
   ) =>
       ClientCommon.queryArrayWithOptions(this, config);
 
-  /// [deno-postgres@v0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
+  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
   Future<QueryObjectResult<T>> queryObject<T>(
     String query, [
     QueryArguments? arguments,
   ]) =>
       ClientCommon.queryObject(this, query, arguments);
 
-  /// [deno-postgres@v0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
+  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
   Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     QueryObjectOptions config,
   ) =>

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -11,34 +11,34 @@ import 'package:deno_postgres_interop/src/transaction.dart';
 import 'package:deno_postgres_interop/src/transaction_options.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
+/// [deno-postgres@v​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
 @JS()
 class QueryClient {
-  /// [deno-postgres@​0.17.0/QueryClient/session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_session).
+  /// [deno-postgres@v​0.17.0/QueryClient/session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_session).
   external Session get session;
 
-  /// [deno-postgres@​0.17.0/QueryClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#ctor_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#ctor_0).
   external factory QueryClient(Connection connection);
 }
 
-/// [deno-postgres@​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
+/// [deno-postgres@v​0.17.0/QueryClient](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient).
 extension QueryClientProps on QueryClient {
-  /// [deno-postgres@​0.17.0/QueryClient/connected](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_connected).
+  /// [deno-postgres@v​0.17.0/QueryClient/connected](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#accessor_connected).
   bool get isConnected => getProperty(this, 'connected');
 
-  /// [deno-postgres@​0.17.0/QueryClient/closeConnection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_closeConnection_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/closeConnection](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_closeConnection_0).
   Future<void> closeConnection() => callFutureMethod(this, 'closeConnection');
 
-  /// [deno-postgres@​0.17.0/QueryClient/resetSessionMetadata](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_resetSessionMetadata_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/resetSessionMetadata](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_resetSessionMetadata_0).
   void resetSessionMetadata() => callMethod(this, 'resetSessionMetadata', []);
 
-  /// [deno-postgres@​0.17.0/QueryClient/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_connect_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/connect](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_connect_0).
   Future<void> connect() => callFutureMethod(this, 'connect');
 
-  /// [deno-postgres@​0.17.0/QueryClient/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_end_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/end](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_end_0).
   Future<void> end() => callFutureMethod(this, 'end');
 
-  /// [deno-postgres@​0.17.0/QueryClient/createTransaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_createTransaction_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/createTransaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_createTransaction_0).
   Transaction createTransaction(String name, [TransactionOptions? options]) =>
       callMethod(
         this,
@@ -65,27 +65,27 @@ extension QueryClientProps on QueryClient {
     return result;
   }
 
-  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_0).
   Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     String query, [
     QueryArguments? args,
   ]) =>
       ClientCommon.queryArray(this, query, args);
 
-  /// [deno-postgres@​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryArray_1).
   Future<QueryArrayResult<T>> queryArrayWithOptions<T extends List<dynamic>>(
     QueryObjectOptions config,
   ) =>
       ClientCommon.queryArrayWithOptions(this, config);
 
-  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_0).
   Future<QueryObjectResult<T>> queryObject<T>(
     String query, [
     QueryArguments? arguments,
   ]) =>
       ClientCommon.queryObject(this, query, arguments);
 
-  /// [deno-postgres@​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
+  /// [deno-postgres@v​0.17.0/QueryClient/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#method_queryObject_1).
   Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     QueryObjectOptions config,
   ) =>

--- a/lib/src/query_object_options.dart
+++ b/lib/src/query_object_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/query_options.dart';
 
-/// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
+/// [deno-postgres@v​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
 @JS()
 class QueryObjectOptions extends QueryOptions {
-  /// [deno-postgres@​0.17.0/QueryObjectOptions/fields](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_fields).
+  /// [deno-postgres@v​0.17.0/QueryObjectOptions/fields](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_fields).
   external List<String>? get fields;
 
-  /// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/query/mod.ts?s=QueryObjectOptions).
+  /// [deno-postgres@v​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/query/mod.ts?s=QueryObjectOptions).
   factory QueryObjectOptions({List<String>? fields, bool? isCamelCase}) =>
       jsify(
         {
@@ -19,8 +19,8 @@ class QueryObjectOptions extends QueryOptions {
       ) as QueryObjectOptions;
 }
 
-/// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
+/// [deno-postgres@v​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
 extension QueryObjectOptionsProps on QueryObjectOptions {
-  /// [deno-postgres@​0.17.0/QueryObjectOptions/camelcase](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_camelcase).
+  /// [deno-postgres@v​0.17.0/QueryObjectOptions/camelcase](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_camelcase).
   bool? get isCamelCase => getProperty(this, 'camelcase');
 }

--- a/lib/src/query_object_options.dart
+++ b/lib/src/query_object_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/query_options.dart';
 
-/// [deno-postgres@v0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
+/// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
 @JS()
 class QueryObjectOptions extends QueryOptions {
-  /// [deno-postgres@v0.17.0/QueryObjectOptions/fields](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_fields).
+  /// [deno-postgres@​0.17.0/QueryObjectOptions/fields](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_fields).
   external List<String>? get fields;
 
-  /// [deno-postgres@v0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/query/mod.ts?s=QueryObjectOptions).
+  /// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/query/mod.ts?s=QueryObjectOptions).
   factory QueryObjectOptions({List<String>? fields, bool? isCamelCase}) =>
       jsify(
         {
@@ -19,8 +19,8 @@ class QueryObjectOptions extends QueryOptions {
       ) as QueryObjectOptions;
 }
 
-/// [deno-postgres@v0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
+/// [deno-postgres@​0.17.0/QueryObjectOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryObjectOptions).
 extension QueryObjectOptionsProps on QueryObjectOptions {
-  /// [deno-postgres@v0.17.0/QueryObjectOptions/camelcase](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_camelcase).
+  /// [deno-postgres@​0.17.0/QueryObjectOptions/camelcase](https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient#prop_camelcase).
   bool? get isCamelCase => getProperty(this, 'camelcase');
 }

--- a/lib/src/query_object_result.dart
+++ b/lib/src/query_object_result.dart
@@ -4,19 +4,19 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/query_result.dart';
 
-/// [deno-postgres@​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
+/// [deno-postgres@v​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
 @JS()
 class QueryObjectResult<T> extends QueryResult {
-  /// [deno-postgres@​0.17.0/QueryObjectResult/columns](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_columns).
+  /// [deno-postgres@v​0.17.0/QueryObjectResult/columns](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_columns).
   external List<String>? get columns;
 
-  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryObjectResult(Query query);
 }
 
-/// [deno-postgres@​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
+/// [deno-postgres@v​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
 extension QueryObjectResultProps<T> on QueryObjectResult<T> {
-  /// [deno-postgres@​0.17.0/QueryObjectResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_rows).
+  /// [deno-postgres@v​0.17.0/QueryObjectResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_rows).
   List<Map<String, dynamic>> get rows =>
       // ignore: cast_nullable_to_non_nullable
       (dartify(getProperty(this, 'rows')) as List)

--- a/lib/src/query_object_result.dart
+++ b/lib/src/query_object_result.dart
@@ -4,19 +4,19 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/query_result.dart';
 
-/// [deno-postgres@v0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
+/// [deno-postgres@​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
 @JS()
 class QueryObjectResult<T> extends QueryResult {
-  /// [deno-postgres@v0.17.0/QueryObjectResult/columns](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_columns).
+  /// [deno-postgres@​0.17.0/QueryObjectResult/columns](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_columns).
   external List<String>? get columns;
 
-  /// [deno-postgres@v0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryObjectResult(Query query);
 }
 
-/// [deno-postgres@v0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
+/// [deno-postgres@​0.17.0/QueryObjectResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult).
 extension QueryObjectResultProps<T> on QueryObjectResult<T> {
-  /// [deno-postgres@v0.17.0/QueryObjectResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_rows).
+  /// [deno-postgres@​0.17.0/QueryObjectResult/rows](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryObjectResult#prop_rows).
   List<Map<String, dynamic>> get rows =>
       // ignore: cast_nullable_to_non_nullable
       (dartify(getProperty(this, 'rows')) as List)

--- a/lib/src/query_options.dart
+++ b/lib/src/query_options.dart
@@ -4,22 +4,22 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/client_common.dart';
 import 'package:deno_postgres_interop/src/encoded_arg.dart';
 
-/// [deno-postgres@​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
+/// [deno-postgres@v​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
 @JS()
 class QueryOptions {
-  /// [deno-postgres@​0.17.0/QueryOptions/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_args).
+  /// [deno-postgres@v​0.17.0/QueryOptions/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_args).
   external QueryArguments? get args;
 
-  /// [deno-postgres@​0.17.0/QueryOptions/encoder](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_encoder).
+  /// [deno-postgres@v​0.17.0/QueryOptions/encoder](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_encoder).
   external EncodedArg Function(dynamic arg)? get encoder;
 
-  /// [deno-postgres@​0.17.0/QueryOptions/name](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_name).
+  /// [deno-postgres@v​0.17.0/QueryOptions/name](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_name).
   external String? get name;
 
-  /// [deno-postgres@​0.17.0/QueryOptions/text](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_text.
+  /// [deno-postgres@v​0.17.0/QueryOptions/text](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_text.
   external String get text;
 
-  /// [deno-postgres@​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
+  /// [deno-postgres@v​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
   factory QueryOptions({
     required String text,
     QueryArguments? args,

--- a/lib/src/query_options.dart
+++ b/lib/src/query_options.dart
@@ -4,22 +4,22 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/client_common.dart';
 import 'package:deno_postgres_interop/src/encoded_arg.dart';
 
-/// [deno-postgres@v0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
+/// [deno-postgres@​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
 @JS()
 class QueryOptions {
-  /// [deno-postgres@v0.17.0/QueryOptions/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_args).
+  /// [deno-postgres@​0.17.0/QueryOptions/args](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_args).
   external QueryArguments? get args;
 
-  /// [deno-postgres@v0.17.0/QueryOptions/encoder](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_encoder).
+  /// [deno-postgres@​0.17.0/QueryOptions/encoder](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_encoder).
   external EncodedArg Function(dynamic arg)? get encoder;
 
-  /// [deno-postgres@v0.17.0/QueryOptions/name](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_name).
+  /// [deno-postgres@​0.17.0/QueryOptions/name](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_name).
   external String? get name;
 
-  /// [deno-postgres@v0.17.0/QueryOptions/text](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_text.
+  /// [deno-postgres@​0.17.0/QueryOptions/text](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions#prop_text.
   external String get text;
 
-  /// [deno-postgres@v0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
+  /// [deno-postgres@​0.17.0/QueryOptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryOptions).
   factory QueryOptions({
     required String text,
     QueryArguments? args,

--- a/lib/src/query_result.dart
+++ b/lib/src/query_result.dart
@@ -6,37 +6,37 @@ import 'package:deno_postgres_interop/src/notice.dart';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/row_description.dart';
 
-/// [deno-postgres@v0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
+/// [deno-postgres@​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
 @JS()
 class QueryResult {
-  /// [deno-postgres@v0.17.0/QueryResult/rowCount](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_rowCount).
+  /// [deno-postgres@​0.17.0/QueryResult/rowCount](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_rowCount).
   external int? get rowCount;
 
-  /// [deno-postgres@v0.17.0/QueryResult/warnings](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_warnings).
+  /// [deno-postgres@​0.17.0/QueryResult/warnings](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_warnings).
   external List<Notice> get warnings;
 
-  /// [deno-postgres@v0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external Query get query;
 
-  /// [deno-postgres@v0.17.0/QueryResult/rowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#accessor_rowDescription).
+  /// [deno-postgres@​0.17.0/QueryResult/rowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#accessor_rowDescription).
   external RowDescription? get rowDescription;
 
-  /// [deno-postgres@v0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryResult(Query query);
 
-  /// [deno-postgres@v0.17.0/QueryResult/handleCommandComplete](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_handleCommandComplete_0).
+  /// [deno-postgres@​0.17.0/QueryResult/handleCommandComplete](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_handleCommandComplete_0).
   external void handleCommandComplete(String commandTag);
 
-  /// [deno-postgres@v0.17.0/QueryResult/loadColumnDescriptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_loadColumnDescriptions_0).
+  /// [deno-postgres@​0.17.0/QueryResult/loadColumnDescriptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_loadColumnDescriptions_0).
   external void loadColumnDescriptions(RowDescription description);
 }
 
-/// [deno-postgres@v0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
+/// [deno-postgres@​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
 extension QueryResultProps on QueryResult {
-  /// [deno-postgres@v0.17.0/QueryResult/insertRow](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_insertRow_0).
+  /// [deno-postgres@​0.17.0/QueryResult/insertRow](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_insertRow_0).
   void insertRow(List<List<int>> row) => callMethod(this, 'insertRow', [row]);
 
-  /// [deno-postgres@v0.17.0/QueryResult/command](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_command).
+  /// [deno-postgres@​0.17.0/QueryResult/command](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_command).
   CommandType get command => CommandType.parse(
         getProperty(this, 'command'),
       );

--- a/lib/src/query_result.dart
+++ b/lib/src/query_result.dart
@@ -6,37 +6,37 @@ import 'package:deno_postgres_interop/src/notice.dart';
 import 'package:deno_postgres_interop/src/query.dart';
 import 'package:deno_postgres_interop/src/row_description.dart';
 
-/// [deno-postgres@​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
+/// [deno-postgres@v​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
 @JS()
 class QueryResult {
-  /// [deno-postgres@​0.17.0/QueryResult/rowCount](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_rowCount).
+  /// [deno-postgres@v​0.17.0/QueryResult/rowCount](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_rowCount).
   external int? get rowCount;
 
-  /// [deno-postgres@​0.17.0/QueryResult/warnings](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_warnings).
+  /// [deno-postgres@v​0.17.0/QueryResult/warnings](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_warnings).
   external List<Notice> get warnings;
 
-  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external Query get query;
 
-  /// [deno-postgres@​0.17.0/QueryResult/rowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#accessor_rowDescription).
+  /// [deno-postgres@v​0.17.0/QueryResult/rowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#accessor_rowDescription).
   external RowDescription? get rowDescription;
 
-  /// [deno-postgres@​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/constructor](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#ctor_0).
   external factory QueryResult(Query query);
 
-  /// [deno-postgres@​0.17.0/QueryResult/handleCommandComplete](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_handleCommandComplete_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/handleCommandComplete](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_handleCommandComplete_0).
   external void handleCommandComplete(String commandTag);
 
-  /// [deno-postgres@​0.17.0/QueryResult/loadColumnDescriptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_loadColumnDescriptions_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/loadColumnDescriptions](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_loadColumnDescriptions_0).
   external void loadColumnDescriptions(RowDescription description);
 }
 
-/// [deno-postgres@​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
+/// [deno-postgres@v​0.17.0/QueryResult](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult).
 extension QueryResultProps on QueryResult {
-  /// [deno-postgres@​0.17.0/QueryResult/insertRow](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_insertRow_0).
+  /// [deno-postgres@v​0.17.0/QueryResult/insertRow](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#method_insertRow_0).
   void insertRow(List<List<int>> row) => callMethod(this, 'insertRow', [row]);
 
-  /// [deno-postgres@​0.17.0/QueryResult/command](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_command).
+  /// [deno-postgres@v​0.17.0/QueryResult/command](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=QueryResult#prop_command).
   CommandType get command => CommandType.parse(
         getProperty(this, 'command'),
       );

--- a/lib/src/result_type.dart
+++ b/lib/src/result_type.dart
@@ -1,4 +1,4 @@
-/// [deno-postgres@​0.17.0/ResultType](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=ResultType).
+/// [deno-postgres@v​0.17.0/ResultType](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=ResultType).
 enum ResultType {
   /// array.
   array,

--- a/lib/src/result_type.dart
+++ b/lib/src/result_type.dart
@@ -1,4 +1,4 @@
-/// [deno-postgres@v0.17.0/ResultType](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=ResultType).
+/// [deno-postgres@​0.17.0/ResultType](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=ResultType).
 enum ResultType {
   /// array.
   array,

--- a/lib/src/row_description.dart
+++ b/lib/src/row_description.dart
@@ -2,7 +2,7 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/column.dart';
 
-/// [deno-postgres@​0.17.0/RowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription).
+/// [deno-postgres@v​0.17.0/RowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription).
 @JS()
 class RowDescription {
   /// https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription#ctor_0

--- a/lib/src/row_description.dart
+++ b/lib/src/row_description.dart
@@ -2,7 +2,7 @@ import 'dart:js_interop';
 
 import 'package:deno_postgres_interop/src/column.dart';
 
-/// [deno-postgres@v0.17.0/RowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription).
+/// [deno-postgres@​0.17.0/RowDescription](https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription).
 @JS()
 class RowDescription {
   /// https://deno.land/x/postgres@v0.17.0/query/query.ts?s=RowDescription#ctor_0

--- a/lib/src/savepoint.dart
+++ b/lib/src/savepoint.dart
@@ -4,10 +4,10 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/promise.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
+/// [deno-postgres@v​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
 @JS()
 class Savepoint {
-  /// [deno-postgres@​0.17.0/Savepoint/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#ctor_0).
+  /// [deno-postgres@v​0.17.0/Savepoint/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#ctor_0).
   factory Savepoint(
     String name,
     Future<void> Function(String name) updateCallback,
@@ -20,14 +20,14 @@ class Savepoint {
       ]);
 }
 
-/// [deno-postgres@​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
+/// [deno-postgres@v​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
 extension SavepointProps on Savepoint {
-  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#accessor_instances).
+  /// [deno-postgres@v​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#accessor_instances).
   int get instancesCount => getProperty(this, 'instances');
 
-  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_release_0).
+  /// [deno-postgres@v​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_release_0).
   Future<void> release() => callFutureMethod(this, 'release');
 
-  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_update_0).
+  /// [deno-postgres@v​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_update_0).
   Future<void> update() => callFutureMethod(this, 'update');
 }

--- a/lib/src/savepoint.dart
+++ b/lib/src/savepoint.dart
@@ -4,10 +4,10 @@ import 'dart:js_util';
 import 'package:deno_postgres_interop/src/promise.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
+/// [deno-postgres@​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
 @JS()
 class Savepoint {
-  /// [deno-postgres@v0.17.0/Savepoint/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#ctor_0).
+  /// [deno-postgres@​0.17.0/Savepoint/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#ctor_0).
   factory Savepoint(
     String name,
     Future<void> Function(String name) updateCallback,
@@ -20,14 +20,14 @@ class Savepoint {
       ]);
 }
 
-/// [deno-postgres@v0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
+/// [deno-postgres@​0.17.0/Savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint).
 extension SavepointProps on Savepoint {
-  /// [deno-postgres@v0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#accessor_instances).
+  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#accessor_instances).
   int get instancesCount => getProperty(this, 'instances');
 
-  /// [deno-postgres@v0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_release_0).
+  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_release_0).
   Future<void> release() => callFutureMethod(this, 'release');
 
-  /// [deno-postgres@v0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_update_0).
+  /// [deno-postgres@​0.17.0/Savepoint/instances](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Savepoint#method_update_0).
   Future<void> update() => callFutureMethod(this, 'update');
 }

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -3,22 +3,22 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
+/// [deno-postgres@v​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
 @JS()
 class Session {
-  /// [deno-postgres@​0.17.0/Session/pid](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_pid)
+  /// [deno-postgres@v​0.17.0/Session/pid](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_pid)
   external int? get pid;
 
-  /// [deno-postgres@​0.17.0/Session/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_tls)
+  /// [deno-postgres@v​0.17.0/Session/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_tls)
   external bool? get tls;
 }
 
-/// [deno-postgres@​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
+/// [deno-postgres@v​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
 extension SessionProps on Session {
-  /// [deno-postgres@​0.17.0/Session/current_transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_current_transaction)
+  /// [deno-postgres@v​0.17.0/Session/current_transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_current_transaction)
   String? get currentTransacton => getProperty(this, 'current_transaction');
 
-  /// [deno-postgres@​0.17.0/Session/transport](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_transport)
+  /// [deno-postgres@v​0.17.0/Session/transport](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_transport)
   Transport? get transport {
     final string = getProperty<String?>(this, 'transport');
 

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -3,22 +3,22 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/transport.dart';
 
-/// [deno-postgres@v0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
+/// [deno-postgres@​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
 @JS()
 class Session {
-  /// [deno-postgres@v0.17.0/Session/pid](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_pid)
+  /// [deno-postgres@​0.17.0/Session/pid](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_pid)
   external int? get pid;
 
-  /// [deno-postgres@v0.17.0/Session/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_tls)
+  /// [deno-postgres@​0.17.0/Session/tls](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_tls)
   external bool? get tls;
 }
 
-/// [deno-postgres@v0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
+/// [deno-postgres@​0.17.0/Session](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session).
 extension SessionProps on Session {
-  /// [deno-postgres@v0.17.0/Session/current_transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_current_transaction)
+  /// [deno-postgres@​0.17.0/Session/current_transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_current_transaction)
   String? get currentTransacton => getProperty(this, 'current_transaction');
 
-  /// [deno-postgres@v0.17.0/Session/transport](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_transport)
+  /// [deno-postgres@​0.17.0/Session/transport](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Session#prop_transport)
   Transport? get transport {
     final string = getProperty<String?>(this, 'transport');
 

--- a/lib/src/tls_options.dart
+++ b/lib/src/tls_options.dart
@@ -1,13 +1,13 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+/// [deno-postgres@v​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
 @JS()
 class TLSOptions {
-  /// [deno-postgres@​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_caCertificates).
+  /// [deno-postgres@v​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_caCertificates).
   external List<String> get caCertificates;
 
-  /// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+  /// [deno-postgres@v​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
   factory TLSOptions({
     required List<String> caCertificates,
     required bool isEnabled,
@@ -20,11 +20,11 @@ class TLSOptions {
       }) as TLSOptions;
 }
 
-/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+/// [deno-postgres@v​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
 extension TLSOptionsProps on TLSOptions {
-  /// [deno-postgres@​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enabled).
+  /// [deno-postgres@v​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enabled).
   bool get isEnabled => getProperty(this, 'isEnabled');
 
-  /// [deno-postgres@​0.17.0/TLSOptions/enforce](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enforce).
+  /// [deno-postgres@v​0.17.0/TLSOptions/enforce](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enforce).
   bool get isEnforced => getProperty(this, 'enforce');
 }

--- a/lib/src/tls_options.dart
+++ b/lib/src/tls_options.dart
@@ -1,13 +1,13 @@
 import 'dart:js_interop';
 import 'dart:js_util';
 
-/// [deno-postgres@v0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
 @JS()
 class TLSOptions {
-  /// [deno-postgres@v0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_caCertificates).
+  /// [deno-postgres@​0.17.0/TLSOptions/caCertificates](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_caCertificates).
   external List<String> get caCertificates;
 
-  /// [deno-postgres@v0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+  /// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
   factory TLSOptions({
     required List<String> caCertificates,
     required bool isEnabled,
@@ -20,11 +20,11 @@ class TLSOptions {
       }) as TLSOptions;
 }
 
-/// [deno-postgres@v0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
+/// [deno-postgres@​0.17.0/TLSOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions).
 extension TLSOptionsProps on TLSOptions {
-  /// [deno-postgres@v0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enabled).
+  /// [deno-postgres@​0.17.0/TLSOptions/enabled](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enabled).
   bool get isEnabled => getProperty(this, 'isEnabled');
 
-  /// [deno-postgres@v0.17.0/TLSOptions/enforce](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enforce).
+  /// [deno-postgres@​0.17.0/TLSOptions/enforce](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TLSOptions#prop_enforce).
   bool get isEnforced => getProperty(this, 'enforce');
 }

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -15,13 +15,13 @@ import 'package:deno_postgres_interop/src/transaction_options.dart';
 import 'package:deno_postgres_interop/src/undefined.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@v0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
+/// [deno-postgres@​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
 @JS()
 class Transaction {
-  /// [deno-postgres@v0.17.0/Transaction/savepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_savepoints).
+  /// [deno-postgres@​0.17.0/Transaction/savepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_savepoints).
   external List<Savepoint> get savepoints;
 
-  /// [deno-postgres@v0.17.0/Transaction/construtor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#ctor_0).
+  /// [deno-postgres@​0.17.0/Transaction/construtor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#ctor_0).
   factory Transaction({
     required String name,
     required QueryClient client,
@@ -40,20 +40,20 @@ class Transaction {
         ],
       );
 
-  /// [deno-postgres@v0.17.0/Transaction/getSavepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoint_0).
+  /// [deno-postgres@​0.17.0/Transaction/getSavepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoint_0).
   external Savepoint? getSavepoint(String name);
 }
 
-/// [deno-postgres@v0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
+/// [deno-postgres@​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
 extension TransactionProps on Transaction {
-  /// [deno-postgres@v0.17.0/Transaction/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_isolation_level).
+  /// [deno-postgres@​0.17.0/Transaction/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_isolation_level).
   IsolationLevel get isolationLevel =>
       IsolationLevel.parse(getProperty(this, 'isolation_name'));
 
-  /// [deno-postgres@v0.17.0/Transaction/begin](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_begin_0).
+  /// [deno-postgres@​0.17.0/Transaction/begin](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_begin_0).
   Future<void> begin() => callFutureMethod(this, 'begin');
 
-  /// [deno-postgres@v0.17.0/Transaction/commit](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_commit_0).
+  /// [deno-postgres@​0.17.0/Transaction/commit](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_commit_0).
   Future<void> commit({bool? chain}) => callFutureMethod(
         this,
         'commit',
@@ -62,38 +62,38 @@ extension TransactionProps on Transaction {
         ],
       );
 
-  /// [deno-postgres@v0.17.0/Transaction/getSavepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoints_0).
+  /// [deno-postgres@​0.17.0/Transaction/getSavepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoints_0).
   List<String> getActiveSavepointsNames() =>
       callMethod(this, 'getSavepoints', []);
 
-  /// [deno-postgres@v0.17.0/Transaction/getSnapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSnapshot_0).
+  /// [deno-postgres@​0.17.0/Transaction/getSnapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSnapshot_0).
   Future<String> get snapshot => callFutureMethod(this, 'getSnapshot');
 
-  /// [deno-postgres@v0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
+  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
   Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     String query, [
     QueryArguments? args,
   ]) =>
       ClientCommon.queryArray(this, query, args);
 
-  /// [deno-postgres@v0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
+  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
   Future<QueryArrayResult<T>> queryArrayWithOptions<T extends List<dynamic>>(
     QueryObjectOptions config,
   ) =>
       ClientCommon.queryArrayWithOptions(this, config);
 
-  /// [deno-postgres@v0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
+  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
   Future<void> rollback([Savepoint? savepoint]) => callFutureMethod(
         this,
         'rollback',
         [if (savepoint != null) savepoint],
       );
 
-  // [deno-postgres@v0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_1).
+  // [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_1).
   // this has the same functionality as [rollback] and [rollbackByName]
   // so it won't be implemented.
 
-  /// [deno-postgres@v0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_2).
+  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_2).
   Future<void> rollbackWithChain() => callFutureMethod(
         this,
         'rollback',
@@ -102,22 +102,22 @@ extension TransactionProps on Transaction {
         ],
       );
 
-  /// [deno-postgres@v0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
+  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
   Future<void> rollbackByName(String savepoint) =>
       callFutureMethod(this, 'rollback', [savepoint]);
 
-  /// [deno-postgres@v0.17.0/Transaction/savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_savepoint_0).
+  /// [deno-postgres@​0.17.0/Transaction/savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_savepoint_0).
   Future<Savepoint> createSavepoint(String name) =>
       callFutureMethod(this, 'savepoint', [name]);
 
-  /// [deno-postgres@v0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
+  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
   Future<QueryObjectResult<T>> queryObject<T>(
     String query, [
     QueryArguments? arguments,
   ]) =>
       ClientCommon.queryObject(this, query, arguments);
 
-  /// [deno-postgres@v0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
+  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
   Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     QueryObjectOptions config,
   ) =>

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -15,13 +15,13 @@ import 'package:deno_postgres_interop/src/transaction_options.dart';
 import 'package:deno_postgres_interop/src/undefined.dart';
 import 'package:deno_postgres_interop/src/util.dart';
 
-/// [deno-postgres@​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
+/// [deno-postgres@v​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
 @JS()
 class Transaction {
-  /// [deno-postgres@​0.17.0/Transaction/savepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_savepoints).
+  /// [deno-postgres@v​0.17.0/Transaction/savepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_savepoints).
   external List<Savepoint> get savepoints;
 
-  /// [deno-postgres@​0.17.0/Transaction/construtor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#ctor_0).
+  /// [deno-postgres@v​0.17.0/Transaction/construtor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#ctor_0).
   factory Transaction({
     required String name,
     required QueryClient client,
@@ -40,20 +40,20 @@ class Transaction {
         ],
       );
 
-  /// [deno-postgres@​0.17.0/Transaction/getSavepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoint_0).
+  /// [deno-postgres@v​0.17.0/Transaction/getSavepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoint_0).
   external Savepoint? getSavepoint(String name);
 }
 
-/// [deno-postgres@​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
+/// [deno-postgres@v​0.17.0/Transaction](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction).
 extension TransactionProps on Transaction {
-  /// [deno-postgres@​0.17.0/Transaction/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_isolation_level).
+  /// [deno-postgres@v​0.17.0/Transaction/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#accessor_isolation_level).
   IsolationLevel get isolationLevel =>
       IsolationLevel.parse(getProperty(this, 'isolation_name'));
 
-  /// [deno-postgres@​0.17.0/Transaction/begin](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_begin_0).
+  /// [deno-postgres@v​0.17.0/Transaction/begin](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_begin_0).
   Future<void> begin() => callFutureMethod(this, 'begin');
 
-  /// [deno-postgres@​0.17.0/Transaction/commit](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_commit_0).
+  /// [deno-postgres@v​0.17.0/Transaction/commit](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_commit_0).
   Future<void> commit({bool? chain}) => callFutureMethod(
         this,
         'commit',
@@ -62,38 +62,38 @@ extension TransactionProps on Transaction {
         ],
       );
 
-  /// [deno-postgres@​0.17.0/Transaction/getSavepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoints_0).
+  /// [deno-postgres@v​0.17.0/Transaction/getSavepoints](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSavepoints_0).
   List<String> getActiveSavepointsNames() =>
       callMethod(this, 'getSavepoints', []);
 
-  /// [deno-postgres@​0.17.0/Transaction/getSnapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSnapshot_0).
+  /// [deno-postgres@v​0.17.0/Transaction/getSnapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_getSnapshot_0).
   Future<String> get snapshot => callFutureMethod(this, 'getSnapshot');
 
-  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
+  /// [deno-postgres@v​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_0).
   Future<QueryArrayResult<T>> queryArray<T extends List<dynamic>>(
     String query, [
     QueryArguments? args,
   ]) =>
       ClientCommon.queryArray(this, query, args);
 
-  /// [deno-postgres@​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
+  /// [deno-postgres@v​0.17.0/Transaction/queryArray](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryArray_1).
   Future<QueryArrayResult<T>> queryArrayWithOptions<T extends List<dynamic>>(
     QueryObjectOptions config,
   ) =>
       ClientCommon.queryArrayWithOptions(this, config);
 
-  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
+  /// [deno-postgres@v​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
   Future<void> rollback([Savepoint? savepoint]) => callFutureMethod(
         this,
         'rollback',
         [if (savepoint != null) savepoint],
       );
 
-  // [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_1).
+  // [deno-postgres@v​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_1).
   // this has the same functionality as [rollback] and [rollbackByName]
   // so it won't be implemented.
 
-  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_2).
+  /// [deno-postgres@v​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_2).
   Future<void> rollbackWithChain() => callFutureMethod(
         this,
         'rollback',
@@ -102,22 +102,22 @@ extension TransactionProps on Transaction {
         ],
       );
 
-  /// [deno-postgres@​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
+  /// [deno-postgres@v​0.17.0/Transaction/rollback](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_rollback_0).
   Future<void> rollbackByName(String savepoint) =>
       callFutureMethod(this, 'rollback', [savepoint]);
 
-  /// [deno-postgres@​0.17.0/Transaction/savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_savepoint_0).
+  /// [deno-postgres@v​0.17.0/Transaction/savepoint](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_savepoint_0).
   Future<Savepoint> createSavepoint(String name) =>
       callFutureMethod(this, 'savepoint', [name]);
 
-  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
+  /// [deno-postgres@v​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_0).
   Future<QueryObjectResult<T>> queryObject<T>(
     String query, [
     QueryArguments? arguments,
   ]) =>
       ClientCommon.queryObject(this, query, arguments);
 
-  /// [deno-postgres@​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
+  /// [deno-postgres@v​0.17.0/Transaction/queryObject](https://deno.land/x/postgres@v0.17.0/mod.ts?s=Transaction#method_queryObject_1).
   Future<QueryObjectResult<T>> queryObjectWithOptions<T>(
     QueryObjectOptions config,
   ) =>

--- a/lib/src/transaction_options.dart
+++ b/lib/src/transaction_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/isolation_level.dart';
 
-/// [deno-postgres@v0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+/// [deno-postgres@​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
 @JS()
 class TransactionOptions {
-  /// [deno-postgres@v0.17.0/TransactionOptions/snapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@​0.17.0/TransactionOptions/snapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   external String? get snapshot;
 
-  /// [deno-postgres@v0.17.0/TransactionOptions/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@​0.17.0/TransactionOptions/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   factory TransactionOptions({
     IsolationLevel? isolationLevel,
     bool? isReadOnly,
@@ -22,15 +22,15 @@ class TransactionOptions {
       }) as TransactionOptions;
 }
 
-/// [deno-postgres@v0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+/// [deno-postgres@​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
 extension TransactionOptionsProps on TransactionOptions {
-  /// [deno-postgres@v0.17.0/TransactionOptions/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@​0.17.0/TransactionOptions/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   IsolationLevel? get isolationLevel {
     final jsProperty = getProperty<String?>(this, 'isolation_level');
 
     return jsProperty == null ? null : IsolationLevel.parse(jsProperty);
   }
 
-  /// [deno-postgres@v0.17.0/TransactionOptions/read_only](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@​0.17.0/TransactionOptions/read_only](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   bool? get isReadOnly => getProperty(this, 'read_only');
 }

--- a/lib/src/transaction_options.dart
+++ b/lib/src/transaction_options.dart
@@ -3,13 +3,13 @@ import 'dart:js_util';
 
 import 'package:deno_postgres_interop/src/isolation_level.dart';
 
-/// [deno-postgres@​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+/// [deno-postgres@v​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
 @JS()
 class TransactionOptions {
-  /// [deno-postgres@​0.17.0/TransactionOptions/snapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@v​0.17.0/TransactionOptions/snapshot](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   external String? get snapshot;
 
-  /// [deno-postgres@​0.17.0/TransactionOptions/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@v​0.17.0/TransactionOptions/constructor](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   factory TransactionOptions({
     IsolationLevel? isolationLevel,
     bool? isReadOnly,
@@ -22,15 +22,15 @@ class TransactionOptions {
       }) as TransactionOptions;
 }
 
-/// [deno-postgres@​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+/// [deno-postgres@v​0.17.0/TransactionOptions](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
 extension TransactionOptionsProps on TransactionOptions {
-  /// [deno-postgres@​0.17.0/TransactionOptions/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@v​0.17.0/TransactionOptions/isolation_level](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   IsolationLevel? get isolationLevel {
     final jsProperty = getProperty<String?>(this, 'isolation_level');
 
     return jsProperty == null ? null : IsolationLevel.parse(jsProperty);
   }
 
-  /// [deno-postgres@​0.17.0/TransactionOptions/read_only](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
+  /// [deno-postgres@v​0.17.0/TransactionOptions/read_only](https://deno.land/x/postgres@v0.17.0/mod.ts?s=TransactionOptions).
   bool? get isReadOnly => getProperty(this, 'read_only');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deno_postgres_interop
 description:
-  An interop for js package deno-postgres@v​0.17.0 - PostgreSQL
+  An interop for js package deno-postgres - PostgreSQL
   driver that can be used in deno-deploy (supabase edge functions).
 version: 0.0.4
 repository: https://github.com/solid-software/deno_postgres_interop

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deno_postgres_interop
 description:
-  An interop for js package deno-postgres - PostgreSQL
+  An interop for js package deno-postgres@​0.17.0 - PostgreSQL
   driver that can be used in deno-deploy (supabase edge functions).
 version: 0.0.3
 repository: https://github.com/solid-software/deno_postgres_interop

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,4 @@ dev_dependencies:
   solid_lints: ^0.0.19
 
 platforms:
-  windows:
-  macos:
-  linux:
+  web:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deno_postgres_interop
 description:
-  An interop for js package deno-postgres@​0.17.0 - PostgreSQL
+  An interop for js package deno-postgres@v​0.17.0 - PostgreSQL
   driver that can be used in deno-deploy (supabase edge functions).
 version: 0.0.3
 repository: https://github.com/solid-software/deno_postgres_interop

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: deno_postgres_interop
 description:
   An interop for js package deno-postgres@v​0.17.0 - PostgreSQL
   driver that can be used in deno-deploy (supabase edge functions).
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/solid-software/deno_postgres_interop
 
 environment:


### PR DESCRIPTION
Because of the `@` character in doc comments, the links are compiled into `mailto` elements instead of `href`.
I added a zero-width space character after after `@` in these links so now it compiles properly
